### PR TITLE
Add transformer for forwarding response to service result

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $client = ClientFactory::create([
     'password' => 'bar',
     'handler' => HandlerStack::create(
         new MockHandler([
-            new Response(404, [], 'Hello, World! This is a test response.'),
+            new Response(404, [], '"Hello, World! This is a test response."'),
         ])
     ) ,
 ]);

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -8,9 +8,14 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Command\Result;
+use GuzzleHttp\Command\ResultInterface;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use GuzzleHttp\Utils;
 use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ClientFactory
 {
@@ -22,9 +27,9 @@ class ClientFactory
 
         return $guzzleClient;
     }
-
     private static function checkRequiredConfigOptions(array $proividedConfig, string $authType): void
     {
+
         $requiredConfigOptions = self::getRequiredConfigOptions($authType);
 
         foreach ($requiredConfigOptions as $requiredConfigOption) {
@@ -48,8 +53,16 @@ class ClientFactory
         $serviceDescription = new Description($serviceDescriptionContents);
 
         return new GuzzleClient(
-            $httpClient,
-            $serviceDescription,
+            client: $httpClient,
+            description: $serviceDescription,
+            responseToResultTransformer: function (
+                ResponseInterface $response,
+                RequestInterface $request
+            ): ResultInterface {
+                return new Result([
+                    'response' => Utils::jsonDecode((string) $response->getBody(), true)
+                ]);
+            }
         );
     }
 
@@ -72,6 +85,7 @@ class ClientFactory
             'token' => $config['token'],
             'token_secret' => $config['token_secret'],
         ]));
+
         $config['handler'] = $stack;
         $config['auth'] = 'oauth';
 

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -27,9 +27,9 @@ class ClientFactory
 
         return $guzzleClient;
     }
+
     private static function checkRequiredConfigOptions(array $proividedConfig, string $authType): void
     {
-
         $requiredConfigOptions = self::getRequiredConfigOptions($authType);
 
         foreach ($requiredConfigOptions as $requiredConfigOption) {

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -157,9 +157,11 @@ class ClientFactoryTest extends TestCase
 
     private function createMockHandler(int $responseCode): HandlerStack
     {
+        $jsonResponse = '"Hello, World! This is a test response."'; // ensure this is valid json
+
         return HandlerStack::create(
             new MockHandler([
-                new Response($responseCode, [], 'Hello, World! This is a test response.'),
+                new Response($responseCode, [], $jsonResponse),
             ])
         );
     }

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -102,7 +102,12 @@ class ClientFactoryTest extends TestCase
 
         $this->assertTrue($createSite instanceof Command);
 
-        $client->execute($createSite);
+        $result = $client->execute($createSite)->toArray();
+
+        $this->assertEquals(
+            'Hello, World! This is a test response.',
+            $result['response']
+        );
     }
 
     /**

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -102,7 +102,7 @@ class ClientFactoryTest extends TestCase
 
         $this->assertTrue($createSite instanceof Command);
 
-        $result = $client->execute($createSite)->toArray();
+        $result = $client->execute($createSite);
 
         $this->assertEquals(
             'Hello, World! This is a test response.',


### PR DESCRIPTION
Issue: HTTPClient responses were not being forwarded to the Service client results.

Solution: Add a response transformer which forwards the client response to the service result, giving access to the API's response from the service.